### PR TITLE
Removed additional entropy option from parameter name generation as i…

### DIFF
--- a/src/Filter/AbstractFilter.php
+++ b/src/Filter/AbstractFilter.php
@@ -36,7 +36,7 @@ abstract class AbstractFilter implements FilterInterface
      */
     protected function createParamName(string $prefix = ''): string
     {
-        return uniqid($prefix, true);
+        return uniqid($prefix);
     }
 
     /**


### PR DESCRIPTION
…t would introduce a period/float format that was invalid when used with the doctrine query builder